### PR TITLE
Add receive function to enso handlers

### DIFF
--- a/contracts/handler/ExternalSwapHandler/EnsoHandler.sol
+++ b/contracts/handler/ExternalSwapHandler/EnsoHandler.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.17;
 
-import {SafeERC20Upgradeable, IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable-4.9.6/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import {TransferHelper} from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
-import {ErrorLibrary} from "../../library/ErrorLibrary.sol";
-import {IIntentHandler} from "../IIntentHandler.sol";
+import { SafeERC20Upgradeable, IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable-4.9.6/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { TransferHelper } from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
+import { ErrorLibrary } from "../../library/ErrorLibrary.sol";
+import { IIntentHandler } from "../IIntentHandler.sol";
 
 /**
  * @title EnsoHandler
@@ -76,4 +76,7 @@ contract EnsoHandler is IIntentHandler {
 
     return tokens;
   }
+
+  // Function to receive Ether when msg.data is empty
+  receive() external payable {}
 }

--- a/contracts/handler/ExternalSwapHandler/EnsoHandlerBundled.sol
+++ b/contracts/handler/ExternalSwapHandler/EnsoHandlerBundled.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.17;
 
-import {SafeERC20Upgradeable, IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable-4.9.6/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import {TransferHelper} from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
-import {ErrorLibrary} from "../../library/ErrorLibrary.sol";
-import {IIntentHandler} from "../IIntentHandler.sol";
+import { SafeERC20Upgradeable, IERC20Upgradeable } from "@openzeppelin/contracts-upgradeable-4.9.6/token/ERC20/utils/SafeERC20Upgradeable.sol";
+import { TransferHelper } from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
+import { ErrorLibrary } from "../../library/ErrorLibrary.sol";
+import { IIntentHandler } from "../IIntentHandler.sol";
 
 /**
  * @title EnsoHandlerBundled
@@ -60,4 +60,7 @@ contract EnsoHandlerBundled is IIntentHandler {
 
     return tokens;
   }
+
+  // Function to receive Ether when msg.data is empty
+  receive() external payable {}
 }


### PR DESCRIPTION
The Enso handlers require a receive function for the case where any token is swapped to ETH, e.g., swapTokenToETH. Looking at the Enso implementation the token is being swapped to ETH and then wrapped to WETH. 