### PR TITLE
Enhance WithdrawBatch with Intent Verification and Improved Token Handling

### DIFF
--- a/contracts/bundle/IWithdrawBatch.sol
+++ b/contracts/bundle/IWithdrawBatch.sol
@@ -6,6 +6,7 @@ interface IWithdrawBatch {
     address _target,
     address _tokenToWithdraw,
     address user,
+    uint256 _expectedOutputAmount,
     bytes[] memory _callData
   ) external;
 }

--- a/contracts/bundle/WithdrawManager.sol
+++ b/contracts/bundle/WithdrawManager.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.17;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {TransferHelper} from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
-import {TargetWhitelisting, ErrorLibrary} from "./TargetWhitelisting.sol";
-import {IPortfolio} from "../core/interfaces/IPortfolio.sol";
-import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
-import {IWithdrawBatch} from "./IWithdrawBatch.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { TransferHelper } from "@uniswap/lib/contracts/libraries/TransferHelper.sol";
+import { TargetWhitelisting, ErrorLibrary } from "./TargetWhitelisting.sol";
+import { IPortfolio } from "../core/interfaces/IPortfolio.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { IWithdrawBatch } from "./IWithdrawBatch.sol";
 
 /**
  * @title WithdrawManager
@@ -37,6 +37,7 @@ contract WithdrawManager is ReentrancyGuard, TargetWhitelisting {
     address _target,
     address _tokenToWithdraw,
     uint256 _portfolioTokenAmount,
+    uint256 _expectedOutputAmount,
     bytes[] memory _callData
   ) external nonReentrant {
     validateTargetWhitelisting(_target);
@@ -53,6 +54,7 @@ contract WithdrawManager is ReentrancyGuard, TargetWhitelisting {
       _target,
       _tokenToWithdraw,
       user,
+      _expectedOutputAmount,
       _callData
     );
   }

--- a/test/Arbitrum/5_BatchTx.test.ts
+++ b/test/Arbitrum/5_BatchTx.test.ts
@@ -124,7 +124,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       await withdrawBatch.deployed();
 
       const WithdrawManager = await ethers.getContractFactory(
-        "WithdrawManager",
+        "WithdrawManager"
       );
       withdrawManager = await WithdrawManager.deploy();
       await withdrawManager.deployed();
@@ -134,7 +134,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       const _protocolConfig = await upgrades.deployProxy(
         ProtocolConfig,
         [treasury.address, priceOracle.address],
-        { kind: "uups" },
+        { kind: "uups" }
       );
 
       protocolConfig = ProtocolConfig.attach(_protocolConfig.address);
@@ -146,13 +146,13 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       await rebalancingDefult.deployed();
 
       const TokenExclusionManager = await ethers.getContractFactory(
-        "TokenExclusionManager",
+        "TokenExclusionManager"
       );
       const tokenExclusionManagerDefault = await TokenExclusionManager.deploy();
       await tokenExclusionManagerDefault.deployed();
 
       const AssetManagementConfig = await ethers.getContractFactory(
-        "AssetManagementConfig",
+        "AssetManagementConfig"
       );
       const assetManagementConfig = await AssetManagementConfig.deploy();
       await assetManagementConfig.deployed();
@@ -161,7 +161,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       portfolioContract = await Portfolio.deploy();
       await portfolioContract.deployed();
       const PancakeSwapHandler = await ethers.getContractFactory(
-        "UniswapV2Handler",
+        "UniswapV2Handler"
       );
       swapHandler = await PancakeSwapHandler.deploy();
       await swapHandler.deployed();
@@ -188,7 +188,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       await feeModule.deployed();
 
       const TokenRemovalVault = await ethers.getContractFactory(
-        "TokenRemovalVault",
+        "TokenRemovalVault"
       );
       const tokenRemovalVault = await TokenRemovalVault.deploy();
       await tokenRemovalVault.deployed();
@@ -197,13 +197,13 @@ describe.only("Tests for Deposit + Withdrawal", () => {
       await fakePortfolio.deployed();
 
       const VelvetSafeModule = await ethers.getContractFactory(
-        "VelvetSafeModule",
+        "VelvetSafeModule"
       );
       velvetSafeModule = await VelvetSafeModule.deploy();
       await velvetSafeModule.deployed();
 
       const PortfolioFactory = await ethers.getContractFactory(
-        "PortfolioFactory",
+        "PortfolioFactory"
       );
 
       const portfolioFactoryInstance = await upgrades.deployProxy(
@@ -225,16 +225,16 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _protocolConfig: protocolConfig.address,
           },
         ],
-        { kind: "uups" },
+        { kind: "uups" }
       );
 
       portfolioFactory = PortfolioFactory.attach(
-        portfolioFactoryInstance.address,
+        portfolioFactoryInstance.address
       );
 
       await withdrawManager.initialize(
         withdrawBatch.address,
-        portfolioFactory.address,
+        portfolioFactory.address
       );
 
       console.log("portfolioFactory address:", portfolioFactory.address);
@@ -282,10 +282,10 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
       portfolio = await ethers.getContractAt(
         Portfolio__factory.abi,
-        portfolioAddress,
+        portfolioAddress
       );
       const PortfolioCalculations = await ethers.getContractFactory(
-        "PortfolioCalculations",
+        "PortfolioCalculations"
       );
       feeModule0 = FeeModule.attach(await portfolio.feeModule());
       portfolioCalculations = await PortfolioCalculations.deploy();
@@ -293,27 +293,27 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
       portfolio1 = await ethers.getContractAt(
         Portfolio__factory.abi,
-        portfolioAddress1,
+        portfolioAddress1
       );
 
       rebalancing = await ethers.getContractAt(
         Rebalancing__factory.abi,
-        portfolioInfo.rebalancing,
+        portfolioInfo.rebalancing
       );
 
       rebalancing1 = await ethers.getContractAt(
         Rebalancing__factory.abi,
-        portfolioInfo1.rebalancing,
+        portfolioInfo1.rebalancing
       );
 
       tokenExclusionManager = await ethers.getContractAt(
         TokenExclusionManager__factory.abi,
-        portfolioInfo.tokenExclusionManager,
+        portfolioInfo.tokenExclusionManager
       );
 
       tokenExclusionManager1 = await ethers.getContractAt(
         TokenExclusionManager__factory.abi,
-        portfolioInfo1.tokenExclusionManager,
+        portfolioInfo1.tokenExclusionManager
       );
 
       console.log("portfolio deployed to:", portfolio.address);
@@ -333,13 +333,13 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
       it("should revert if not a superAdmin + nonRebalancer contract calls functions", async () => {
         await expect(
-          portfolio.connect(addr2).initToken([addresses.ARB, addresses.WBTC]),
+          portfolio.connect(addr2).initToken([addresses.ARB, addresses.WBTC])
         ).to.be.revertedWithCustomError(portfolio, "CallerNotSuperAdmin");
       });
 
       it("Calling the function mintShares should fail (only callable by contracts)", async () => {
         await expect(
-          portfolio.mintShares(owner.address, "10000000"),
+          portfolio.mintShares(owner.address, "10000000")
         ).to.be.revertedWithCustomError(portfolio, "CallerNotPortfolioManager");
       });
 
@@ -357,7 +357,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             addresses.aArbLINK,
             addresses.aArbUSDC,
             addresses.aArbUSDT,
-          ]),
+          ])
         ).to.be.revertedWithCustomError(portfolio, "TokenCountOutOfLimit");
       });
 
@@ -382,7 +382,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             depositBatch.address,
             "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
             tokens[i],
-            "2000000000000000",
+            "2000000000000000"
           );
           postResponse.push(response.data.tx.data);
         }
@@ -397,7 +397,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
           },
           {
             value: "1000000000000000000",
-          },
+          }
         );
 
         console.log("SupplyAfter", await portfolio.totalSupply());
@@ -418,7 +418,9 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
         let postResponse = [];
 
-        let amountToSwap = "100000000000000000000";
+        let amountToSwap = await ERC20.attach(tokenToSwap).balanceOf(
+          owner.address
+        );
 
         for (let i = 0; i < tokens.length; i++) {
           let amountIn = BigNumber.from(amountToSwap).div(tokens.length);
@@ -432,7 +434,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
               depositBatch.address,
               tokenToSwap,
               tokens[i],
-              Number(amountIn),
+              Number(amountIn)
             );
             postResponse.push(response.data.tx.data);
           }
@@ -442,7 +444,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
         await ERC20.attach(tokenToSwap).approve(
           depositManager.address,
-          amountToSwap.toString(),
+          amountToSwap.toString()
         );
 
         await depositManager.deposit({
@@ -461,7 +463,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
         const permit2 = await ethers.getContractAt(
           "IAllowanceTransfer",
-          PERMIT2_ADDRESS,
+          PERMIT2_ADDRESS
         );
 
         const ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
@@ -472,7 +474,9 @@ describe.only("Tests for Deposit + Withdrawal", () => {
           value: "100000000000000000",
         });
 
-        let amountToSwap = "300000000";
+        let amountToSwap = await ERC20.attach(tokenToSwap).balanceOf(
+          owner.address
+        );
 
         console.log("SupplyBefore", await portfolio.totalSupply());
 
@@ -490,7 +494,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
               depositBatch.address,
               tokenToSwap,
               tokens[i],
-              Number(amountIn),
+              Number(amountIn)
             );
             postResponse.push(response.data.tx.data);
           }
@@ -500,7 +504,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
         await ERC20.attach(tokenToSwap).approve(
           depositManager.address,
-          amountToSwap.toString(),
+          amountToSwap.toString()
         );
 
         await depositManager.deposit({
@@ -532,12 +536,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
             amountPortfolioToken,
-            portfolio.address,
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken)
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -549,12 +553,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
               nonOwner.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
           userBalanceBefore.push(
-            await ERC20.attach(tokens[i]).balanceOf(user.address),
+            await ERC20.attach(tokens[i]).balanceOf(user.address)
           );
         }
 
@@ -563,8 +567,9 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             portfolio.address,
             tokenToSwapInto,
             amountPortfolioToken,
-            responses,
-          ),
+            1000000000000000000000000,
+            responses
+          )
         ).to.be.revertedWithCustomError(withdrawBatch, "InvalidBalanceDiff");
       });
 
@@ -586,12 +591,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
             amountPortfolioToken,
-            portfolio.address,
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken)
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -603,12 +608,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
               nonOwner.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
           userBalanceBefore.push(
-            await ERC20.attach(tokens[i]).balanceOf(user.address),
+            await ERC20.attach(tokens[i]).balanceOf(user.address)
           );
         }
 
@@ -617,15 +622,16 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             portfolio.address,
             tokenToSwapInto,
             amountPortfolioToken,
-            responses,
-          ),
+            1000000000000000000000000,
+            responses
+          )
         ).to.be.revertedWithCustomError(withdrawBatch, "InvalidBalanceDiff");
       });
 
       it("withdrawal should fail if target address is not whitelisted", async () => {
         const user = owner;
         const amountPortfolioToken = BigNumber.from(
-          await portfolio.balanceOf(user.address),
+          await portfolio.balanceOf(user.address)
         ).div(2);
         const tokenToSwapInto = addresses.WBTC;
 
@@ -634,11 +640,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             fakePortfolio.address,
             tokenToSwapInto,
             amountPortfolioToken,
-            ["0x"],
-          ),
+            0,
+            ["0x"]
+          )
         ).to.be.revertedWithCustomError(
           withdrawManager,
-          "InvalidTargetAddress",
+          "InvalidTargetAddress"
         );
       });
 
@@ -650,13 +657,13 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         let responses = [];
 
         const amountPortfolioToken = BigNumber.from(
-          await portfolio.balanceOf(user.address),
+          await portfolio.balanceOf(user.address)
         ).div(2);
 
         const ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
 
         const balanceBefore = await ERC20.attach(tokenToSwapInto).balanceOf(
-          user.address,
+          user.address
         );
 
         const tokens = await portfolio.getTokens();
@@ -666,12 +673,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
             amountPortfolioToken,
-            portfolio.address,
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken)
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -683,12 +690,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
               user.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
           userBalanceBefore.push(
-            await ERC20.attach(tokens[i]).balanceOf(user.address),
+            await ERC20.attach(tokens[i]).balanceOf(user.address)
           );
         }
 
@@ -696,11 +703,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
           portfolio.address,
           tokenToSwapInto,
           amountPortfolioToken,
-          responses,
+          0,
+          responses
         );
 
         const balanceAfter = await ERC20.attach(tokenToSwapInto).balanceOf(
-          user.address,
+          user.address
         );
 
         const supplyAfter = await portfolio.totalSupply();
@@ -717,7 +725,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         let responses = [];
 
         const amountPortfolioToken = BigNumber.from(
-          await portfolio.balanceOf(user.address),
+          await portfolio.balanceOf(user.address)
         ).div(2);
 
         const ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
@@ -729,12 +737,12 @@ describe.only("Tests for Deposit + Withdrawal", () => {
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
             amountPortfolioToken,
-            portfolio.address,
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken)
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -746,7 +754,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
               user.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
@@ -756,7 +764,8 @@ describe.only("Tests for Deposit + Withdrawal", () => {
           portfolio.address,
           tokenToSwapInto,
           amountPortfolioToken,
-          responses,
+          0,
+          responses
         );
 
         const supplyAfter = await portfolio.totalSupply();
@@ -780,7 +789,9 @@ describe.only("Tests for Deposit + Withdrawal", () => {
           value: "100000000000000000",
         });
 
-        let amountToSwap = "100000000000000000000";
+        let amountToSwap = await ERC20.attach(tokenToSwap).balanceOf(
+          owner.address
+        );
 
         for (let i = 0; i < tokens.length; i++) {
           let amountIn = BigNumber.from(amountToSwap).div(tokens.length);
@@ -794,7 +805,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
               depositBatch.address,
               tokenToSwap,
               tokens[i],
-              Number(amountIn),
+              Number(amountIn)
             );
             postResponse.push(response.data.tx.data);
           }
@@ -804,7 +815,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
 
         await ERC20.attach(tokenToSwap).approve(
           depositManager.address,
-          amountToSwap.toString(),
+          amountToSwap.toString()
         );
 
         await expect(
@@ -814,7 +825,7 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             _target: portfolio.address,
             _depositToken: tokenToSwap,
             _callData: postResponse,
-          }),
+          })
         ).to.be.revertedWithCustomError(depositBatch, "InvalidBalanceDiff");
       });
 
@@ -836,8 +847,8 @@ describe.only("Tests for Deposit + Withdrawal", () => {
             },
             {
               value: "1000000000000000000",
-            },
-          ),
+            }
+          )
         ).to.be.revertedWithCustomError(depositBatch, "InvalidLength");
       });
     });

--- a/test/Bsc/5_BatchTx.test.ts
+++ b/test/Bsc/5_BatchTx.test.ts
@@ -84,7 +84,7 @@ describe.only("Tests for Deposit", () => {
   let addrs: SignerWithAddress[];
   let feeModule0: FeeModule;
   const assetManagerHash = ethers.utils.keccak256(
-    ethers.utils.toUtf8Bytes("ASSET_MANAGER"),
+    ethers.utils.toUtf8Bytes("ASSET_MANAGER")
   );
 
   const provider = ethers.provider;
@@ -129,7 +129,7 @@ describe.only("Tests for Deposit", () => {
       await withdrawBatch.deployed();
 
       const WithdrawManager = await ethers.getContractFactory(
-        "WithdrawManager",
+        "WithdrawManager"
       );
       withdrawManager = await WithdrawManager.deploy();
       await withdrawManager.deployed();
@@ -139,7 +139,7 @@ describe.only("Tests for Deposit", () => {
       const _protocolConfig = await upgrades.deployProxy(
         ProtocolConfig,
         [treasury.address, priceOracle.address],
-        { kind: "uups" },
+        { kind: "uups" }
       );
 
       protocolConfig = ProtocolConfig.attach(_protocolConfig.address);
@@ -151,13 +151,13 @@ describe.only("Tests for Deposit", () => {
       await rebalancingDefult.deployed();
 
       const AssetManagementConfig = await ethers.getContractFactory(
-        "AssetManagementConfig",
+        "AssetManagementConfig"
       );
       const assetManagementConfig = await AssetManagementConfig.deploy();
       await assetManagementConfig.deployed();
 
       const TokenExclusionManager = await ethers.getContractFactory(
-        "TokenExclusionManager",
+        "TokenExclusionManager"
       );
       const tokenExclusionManagerDefault = await TokenExclusionManager.deploy();
       await tokenExclusionManagerDefault.deployed();
@@ -166,7 +166,7 @@ describe.only("Tests for Deposit", () => {
       portfolioContract = await Portfolio.deploy();
       await portfolioContract.deployed();
       const PancakeSwapHandler = await ethers.getContractFactory(
-        "UniswapV2Handler",
+        "UniswapV2Handler"
       );
       swapHandler = await PancakeSwapHandler.deploy();
       await swapHandler.deployed();
@@ -195,7 +195,7 @@ describe.only("Tests for Deposit", () => {
       await feeModule.deployed();
 
       const TokenRemovalVault = await ethers.getContractFactory(
-        "TokenRemovalVault",
+        "TokenRemovalVault"
       );
       const tokenRemovalVault = await TokenRemovalVault.deploy();
       await tokenRemovalVault.deployed();
@@ -204,13 +204,13 @@ describe.only("Tests for Deposit", () => {
       await fakePortfolio.deployed();
 
       const VelvetSafeModule = await ethers.getContractFactory(
-        "VelvetSafeModule",
+        "VelvetSafeModule"
       );
       velvetSafeModule = await VelvetSafeModule.deploy();
       await velvetSafeModule.deployed();
 
       const PortfolioFactory = await ethers.getContractFactory(
-        "PortfolioFactory",
+        "PortfolioFactory"
       );
 
       const portfolioFactoryInstance = await upgrades.deployProxy(
@@ -232,16 +232,16 @@ describe.only("Tests for Deposit", () => {
             _protocolConfig: protocolConfig.address,
           },
         ],
-        { kind: "uups" },
+        { kind: "uups" }
       );
 
       portfolioFactory = PortfolioFactory.attach(
-        portfolioFactoryInstance.address,
+        portfolioFactoryInstance.address
       );
 
       await withdrawManager.initialize(
         withdrawBatch.address,
-        portfolioFactory.address,
+        portfolioFactory.address
       );
 
       console.log("portfolioFactory address:", portfolioFactory.address);
@@ -289,10 +289,10 @@ describe.only("Tests for Deposit", () => {
 
       portfolio = await ethers.getContractAt(
         Portfolio__factory.abi,
-        portfolioAddress,
+        portfolioAddress
       );
       const PortfolioCalculations = await ethers.getContractFactory(
-        "PortfolioCalculations",
+        "PortfolioCalculations"
       );
       feeModule0 = FeeModule.attach(await portfolio.feeModule());
       portfolioCalculations = await PortfolioCalculations.deploy();
@@ -300,27 +300,27 @@ describe.only("Tests for Deposit", () => {
 
       portfolio1 = await ethers.getContractAt(
         Portfolio__factory.abi,
-        portfolioAddress1,
+        portfolioAddress1
       );
 
       rebalancing = await ethers.getContractAt(
         Rebalancing__factory.abi,
-        portfolioInfo.rebalancing,
+        portfolioInfo.rebalancing
       );
 
       rebalancing1 = await ethers.getContractAt(
         Rebalancing__factory.abi,
-        portfolioInfo1.rebalancing,
+        portfolioInfo1.rebalancing
       );
 
       tokenExclusionManager = await ethers.getContractAt(
         TokenExclusionManager__factory.abi,
-        portfolioInfo.tokenExclusionManager,
+        portfolioInfo.tokenExclusionManager
       );
 
       tokenExclusionManager1 = await ethers.getContractAt(
         TokenExclusionManager__factory.abi,
-        portfolioInfo1.tokenExclusionManager,
+        portfolioInfo1.tokenExclusionManager
       );
 
       console.log("portfolio deployed to:", portfolio.address);
@@ -353,7 +353,7 @@ describe.only("Tests for Deposit", () => {
             depositBatch.address,
             "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
             tokens[i],
-            "2000000000000000",
+            "2000000000000000"
           );
           postResponse.push(response.data.tx.data);
         }
@@ -368,7 +368,7 @@ describe.only("Tests for Deposit", () => {
           },
           {
             value: "1000000000000000000",
-          },
+          }
         );
 
         console.log("SupplyAfter", await portfolio.totalSupply());
@@ -385,7 +385,9 @@ describe.only("Tests for Deposit", () => {
           value: "1000000000000000000",
         });
 
-        let amountToSwap = "100000000000000000000";
+        let amountToSwap = await ERC20.attach(tokenToSwap).balanceOf(
+          owner.address
+        );
 
         console.log("SupplyBefore", await portfolio.totalSupply());
 
@@ -404,7 +406,7 @@ describe.only("Tests for Deposit", () => {
               depositBatch.address,
               tokenToSwap,
               tokens[i],
-              Number(amountIn),
+              Number(amountIn)
             );
             postResponse.push(response.data.tx.data);
           }
@@ -414,7 +416,7 @@ describe.only("Tests for Deposit", () => {
 
         await ERC20.attach(tokenToSwap).approve(
           depositManager.address,
-          amountToSwap.toString(),
+          amountToSwap.toString()
         );
 
         const data = await depositManager.deposit({
@@ -439,7 +441,9 @@ describe.only("Tests for Deposit", () => {
           value: "100000000000000000",
         });
 
-        let amountToSwap = "3000000000000000000";
+        let amountToSwap = await ERC20.attach(tokenToSwap).balanceOf(
+          owner.address
+        );
 
         console.log("SupplyBefore", await portfolio.totalSupply());
 
@@ -457,7 +461,7 @@ describe.only("Tests for Deposit", () => {
               depositBatch.address,
               tokenToSwap,
               tokens[i],
-              Number(amountIn),
+              Number(amountIn)
             );
             postResponse.push(response.data.tx.data);
           }
@@ -467,7 +471,7 @@ describe.only("Tests for Deposit", () => {
 
         await ERC20.attach(tokenToSwap).approve(
           depositManager.address,
-          amountToSwap.toString(),
+          amountToSwap.toString()
         );
 
         const data = await depositManager.deposit({
@@ -499,13 +503,13 @@ describe.only("Tests for Deposit", () => {
 
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
-            amountPortfolioToken,
-            portfolio.address,
+            amountPortfolioToken.toString(),
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken.toString())
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -517,12 +521,12 @@ describe.only("Tests for Deposit", () => {
               nonOwner.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
           userBalanceBefore.push(
-            await ERC20.attach(tokens[i]).balanceOf(user.address),
+            await ERC20.attach(tokens[i]).balanceOf(user.address)
           );
         }
 
@@ -530,9 +534,10 @@ describe.only("Tests for Deposit", () => {
           withdrawManager.withdraw(
             portfolio.address,
             tokenToSwapInto,
-            amountPortfolioToken,
-            responses,
-          ),
+            amountPortfolioToken.toString(),
+            "1000000000000000000000000",
+            responses
+          )
         ).to.be.revertedWithCustomError(withdrawBatch, "InvalidBalanceDiff");
       });
 
@@ -553,13 +558,13 @@ describe.only("Tests for Deposit", () => {
 
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
-            amountPortfolioToken,
-            portfolio.address,
+            amountPortfolioToken.toString(),
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken.toString())
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -571,12 +576,12 @@ describe.only("Tests for Deposit", () => {
               nonOwner.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
           userBalanceBefore.push(
-            await ERC20.attach(tokens[i]).balanceOf(user.address),
+            await ERC20.attach(tokens[i]).balanceOf(user.address)
           );
         }
 
@@ -584,29 +589,31 @@ describe.only("Tests for Deposit", () => {
           withdrawManager.withdraw(
             portfolio.address,
             tokenToSwapInto,
-            amountPortfolioToken,
-            responses,
-          ),
+            amountPortfolioToken.toString(),
+            "1000000000000000000000000",
+            responses
+          )
         ).to.be.revertedWithCustomError(withdrawBatch, "InvalidBalanceDiff");
       });
 
       it("withdrawal should fail if target address is not whitelisted", async () => {
         const user = owner;
         const amountPortfolioToken = BigNumber.from(
-          await portfolio.balanceOf(user.address),
+          await portfolio.balanceOf(user.address)
         ).div(2);
-        const tokenToSwapInto = addresses.WBTC;
+        const tokenToSwapInto = iaddress.btcAddress;
 
         await expect(
           withdrawManager.withdraw(
             fakePortfolio.address,
             tokenToSwapInto,
             amountPortfolioToken,
-            ["0x"],
-          ),
+            0,
+            ["0x"]
+          )
         ).to.be.revertedWithCustomError(
           withdrawManager,
-          "InvalidTargetAddress",
+          "InvalidTargetAddress"
         );
       });
 
@@ -618,7 +625,7 @@ describe.only("Tests for Deposit", () => {
         let responses = [];
 
         const amountPortfolioToken = BigNumber.from(
-          await portfolio.balanceOf(user.address),
+          await portfolio.balanceOf(user.address)
         ).div(2);
 
         const ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
@@ -630,12 +637,12 @@ describe.only("Tests for Deposit", () => {
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
             amountPortfolioToken,
-            portfolio.address,
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken)
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -647,12 +654,12 @@ describe.only("Tests for Deposit", () => {
               user.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
           userBalanceBefore.push(
-            await ERC20.attach(tokens[i]).balanceOf(user.address),
+            await ERC20.attach(tokens[i]).balanceOf(user.address)
           );
         }
 
@@ -660,18 +667,19 @@ describe.only("Tests for Deposit", () => {
           portfolio.address,
           tokenToSwapInto,
           amountPortfolioToken,
-          responses,
+          0,
+          responses
         );
 
         for (let i = 0; i < tokens.length; i++) {
           let balanceAfter = await ERC20.attach(tokens[i]).balanceOf(
-            owner.address,
+            owner.address
           );
           let balanceOFHandler = await ERC20.attach(tokens[i]).balanceOf(
-            withdrawBatch.address,
+            withdrawBatch.address
           );
           expect(Number(balanceAfter)).to.be.greaterThan(
-            Number(userBalanceBefore[i]),
+            Number(userBalanceBefore[i])
           );
           expect(Number(balanceOFHandler)).to.be.equal(0);
         }
@@ -689,7 +697,7 @@ describe.only("Tests for Deposit", () => {
         let responses = [];
 
         const amountPortfolioToken = BigNumber.from(
-          await portfolio.balanceOf(user.address),
+          await portfolio.balanceOf(user.address)
         ).div(2);
 
         const ERC20 = await ethers.getContractFactory("ERC20Upgradeable");
@@ -701,12 +709,12 @@ describe.only("Tests for Deposit", () => {
         let withdrawalAmounts =
           await portfolioCalculations.getWithdrawalAmounts(
             amountPortfolioToken,
-            portfolio.address,
+            portfolio.address
           );
 
         await portfolio.approve(
           withdrawManager.address,
-          BigNumber.from(amountPortfolioToken),
+          BigNumber.from(amountPortfolioToken)
         );
 
         for (let i = 0; i < tokens.length; i++) {
@@ -718,7 +726,7 @@ describe.only("Tests for Deposit", () => {
               user.address,
               tokens[i],
               tokenToSwapInto,
-              (withdrawalAmounts[i] * 0.9999999).toFixed(0),
+              (withdrawalAmounts[i] * 0.9999999).toFixed(0)
             );
             responses.push(response.data.tx.data);
           }
@@ -728,7 +736,8 @@ describe.only("Tests for Deposit", () => {
           portfolio.address,
           tokenToSwapInto,
           amountPortfolioToken,
-          responses,
+          0,
+          responses
         );
 
         const supplyAfter = await portfolio.totalSupply();
@@ -750,7 +759,9 @@ describe.only("Tests for Deposit", () => {
           value: "1000000000000000000",
         });
 
-        let amountToSwap = "10000000000000000000";
+        let amountToSwap = await ERC20.attach(tokenToSwap).balanceOf(
+          owner.address
+        );
 
         console.log("SupplyBefore", await portfolio.totalSupply());
 
@@ -769,7 +780,7 @@ describe.only("Tests for Deposit", () => {
               depositBatch.address,
               tokenToSwap,
               tokens[i],
-              Number(amountIn),
+              Number(amountIn)
             );
             postResponse.push(response.data.tx.data);
           }
@@ -779,7 +790,7 @@ describe.only("Tests for Deposit", () => {
 
         await ERC20.attach(tokenToSwap).approve(
           depositManager.address,
-          amountToSwap.toString(),
+          amountToSwap.toString()
         );
 
         await expect(
@@ -789,7 +800,7 @@ describe.only("Tests for Deposit", () => {
             _target: portfolio.address,
             _depositToken: tokenToSwap,
             _callData: postResponse,
-          }),
+          })
         ).to.be.revertedWithCustomError(depositBatch, "InvalidBalanceDiff");
       });
 
@@ -811,8 +822,8 @@ describe.only("Tests for Deposit", () => {
             },
             {
               value: "1000000000000000000",
-            },
-          ),
+            }
+          )
         ).to.be.revertedWithCustomError(depositBatch, "InvalidLength");
       });
     });


### PR DESCRIPTION
## Changes

1. Added intent verification to WithdrawBatch:
   - User defines expected output amount when withdrawing
   - Example: If front-end shows $100 and user withdraws in stablecoin, they might expect at least $99 in return
   - Reverts if received amount is less than expected amount

2. Improved token handling:
   - Transfers withdraw tokens to user if sent to contract instead of user (receiver defined in calldata)

## Rationale
- Prevents losses from incorrect calldata or unexpected price movements
- Ensures funds aren't stuck in contract when withdraw token is sent to contract instead of user
- Handles ETH dust from multi-hop swaps (e.g., swaps routed over ETH)